### PR TITLE
initialize stopping

### DIFF
--- a/pathspider/base.py
+++ b/pathspider/base.py
@@ -392,6 +392,8 @@ class Spider:
         with self.lock:
             # set the running flag
             self.running = True
+            
+            self.stopping = False
 
             # create an observer and start its process
             self.observer = self.create_observer()


### PR DESCRIPTION
Pathspider termiated with an Expection in line 557 in base.py:
"AttributeError: 'ECN' object has no attribute 'stopping'"

This line fixes that.

